### PR TITLE
set annovar output as whitelist input

### DIFF
--- a/annovar_whitelist_filter.wdl
+++ b/annovar_whitelist_filter.wdl
@@ -70,7 +70,7 @@ workflow AnnovarAndWhitelistFilter {
     }
 
     if (run_whitelist_or_default) {
-      File whitelist_filter_annovar_txt_input = annovar_annotated_file_table
+      File whitelist_filter_annovar_txt_input = Annovar.annovar_annotated_file_table
       call WhitelistFilter {
         input:
           whitelist_filter_docker = whitelist_filter_docker,


### PR DESCRIPTION
Hi @charliecondon !

Could you please merge this fix?
It fixes the Terra workflow failure with 
```
Error in fread("annovar_out.hg38_multianno.txt") : File 'annovar_out.hg38_multianno.txt' does not exist or is non-readable.
```

Sergey